### PR TITLE
Manage deluge version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ end
 
 desc 'Knife upload deluge cookbook to test environment'
 task :upload_test do
-  sh 'knife cookbook upload -o .. delugeserver -E test'
+  sh 'knife cookbook upload -o .. delugeserver -E test --force'
 end
 
 desc 'Knife upload deluge cookbook to prod environment'
@@ -36,5 +36,5 @@ task remove_test: [:deletenode_test, :deleteclient_test]
 
 desc 'Bootstrap test server'
 task bootstrap_test: [:upload_test] do
-  sh 'knife bootstrap 192.168.1.211 -E test -N testserver -r delugeserver --sudo --ssh-user test --ssh-password test --use-sudo-password'
+  sh 'knife bootstrap 192.168.1.234 -E test -N testserver -r role[delugeserver_role] --sudo --ssh-user test --ssh-password test --use-sudo-password --bootstrap-version 12.19.36'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,9 @@ end
 
 desc 'Run foodcritic in current directory'
 task :foodcritic do
-  sh 'foodcritic .'
+  # ignore databag helper rule: http://www.foodcritic.io/#FC086
+  # it is not clear how to perform this work outside of the .erb file
+  sh 'foodcritic . --tags ~FC086'
 end
 
 desc 'Knife upload deluge cookbook to test environment'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,7 @@
 
+# manage version
+default['deluge']['version'] = '1.3.11-1.el7.nux'
+
 #    manage auth file users
 #
 # If set to true, then the cookbook will create the file

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name 'delugeserver'
 maintainer 'Adam Linkous'
 maintainer_email 'alinkous+support@gmail.com'
-license 'all_rights'
+license 'MIT'
 description 'Installs/Configures delugeserver'
 long_description 'Installs/Configures delugeserver'
 version '2.1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'alinkous+support@gmail.com'
 license 'all_rights'
 description 'Installs/Configures delugeserver'
 long_description 'Installs/Configures delugeserver'
-version '2.0.1'
+version '2.1.0'
 supports 'centos'
 chef_version '~> 12.19' if respond_to?(:chef_version)
 issues_url 'https://github.com/gryte/delugeserver/issues' if respond_to?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,13 +41,15 @@ end
 
 # install deluge-daemon
 package 'deluge-daemon' do
-  action :upgrade
+  version node['deluge']['version']
+  action :install
   notifies :create, 'template[create_systemd_deluged_service]', :immediately
 end
 
 # install deluge-web
 package 'deluge-web' do
-  action :upgrade
+  version node['deluge']['version']
+  action :install
 end
 
 # create deluged.service file
@@ -84,7 +86,8 @@ end
 
 # install deluge-console
 package 'deluge-console' do
-  action :upgrade
+  version node['deluge']['version']
+  action :install
 end
 
 # manage deluge app directories

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -26,6 +26,7 @@ end
 # deluge-web is installed
 describe package('deluge-web') do
   it { should be_installed }
+  its('version') { should eq '1.3.11-1.el7.nux' }
 end
 
 # deluge-web service is enabled and running
@@ -80,6 +81,7 @@ end
 # deluged is installed
 describe package('deluge-daemon') do
   it { should be_installed }
+  its('version') { should eq '1.3.11-1.el7.nux' }
 end
 
 # deluged.service exists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
improve Rakefile

- force test cookbook upload
- bootstrap specific chef-client version
- update testserver ip
- bootstrap role instead of recipe
- bump metadata version

add deluge version

- create node attribute to capture version
- update recipe to install version with attribute

update kitchen test

- add test for deluge version

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- resolves #24

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Certain sites require certain versions of clients to work properly. Adding this feature will ensure we have the ability to accommodate these requirements.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested successfully with both a local kitchen test and on a proxmox test vm.

## Screenshots (if appropriate):
-n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
