### PR TITLE
add guards to version package installs

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'alinkous+support@gmail.com'
 license 'MIT'
 description 'Installs/Configures delugeserver'
 long_description 'Installs/Configures delugeserver'
-version '2.1.2'
+version '2.1.3'
 supports 'centos'
 chef_version '>= 12.19' if respond_to?(:chef_version)
 issues_url 'https://github.com/gryte/delugeserver/issues' if respond_to?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,7 @@ end
 
 # install deluge-daemon
 package 'deluge-daemon' do
+  not_if 'rpm -q deluge-daemon | grep deluge-daemon-1.3.11-1.el7.nux.noarch'
   version node['deluge']['version']
   action :install
   notifies :create, 'template[create_systemd_deluged_service]', :immediately
@@ -48,6 +49,7 @@ end
 
 # install deluge-web
 package 'deluge-web' do
+  not_if 'rpm -q deluge-web | grep deluge-web-1.3.11-1.el7.nux.noarch'
   version node['deluge']['version']
   action :install
 end
@@ -86,6 +88,7 @@ end
 
 # install deluge-console
 package 'deluge-console' do
+  not_if 'rpm -q deluge-console | grep deluge-console-1.3.11-1.el7.nux.noarch'
   version node['deluge']['version']
   action :install
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- add not_if statements to the package resource for installing specific
versions

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- resolves #28

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent unnecessary software installation steps *(try to be idempotent)*.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Kitchen tests with multiple converges show that the resources are skipped appropriately with the additional `not_if` guards.

## Screenshots (if appropriate):
- n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
