### PR TITLE
implement extractor plugin

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,5 +41,6 @@ suites:
               lsd: "false"
               random_port: "false"
           label.conf: true
+          extractor.conf: true
         plugin:
-          enable: ['AutoAdd', 'Label']
+          enable: ['AutoAdd', 'Label', 'Extractor']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,15 +14,16 @@ default['deluge']['config']['auth'] = false
 #
 #    manage configuration files
 #
-# This will create and update the files /var/lib/deluge/.config/deluge/core.conf
-# and /var/lib/deluge/.config/deluge/label.conf. The core.conf file is updated
-# with items from 'settings' via the deluge-console. The label.conf is hard-coded
-# with a label.conf.erb file and requires the current values specified in 'directories'.
+# This will create and update the files /var/lib/deluge/.config/deluge/core.conf,
+# label.conf, and extractor.conf. The core.conf file is updated
+# with items from 'settings' via the deluge-console. The label.conf and extractor.conf are hard-coded
+# with a .erb file and requires the current values specified in 'directories'.
 # See .kitchen.yml for examples.
 #
 default['deluge']['config']['core.conf']['manage'] = false
 default['deluge']['config']['core.conf']['settings'] = {}
 default['deluge']['config']['label.conf'] = false
+default['deluge']['config']['extractor.conf'] = false
 
 #
 #    manage plugins

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'alinkous+support@gmail.com'
 license 'MIT'
 description 'Installs/Configures delugeserver'
 long_description 'Installs/Configures delugeserver'
-version '2.1.3'
+version '2.2.0'
 supports 'centos'
 chef_version '>= 12.19' if respond_to?(:chef_version)
 issues_url 'https://github.com/gryte/delugeserver/issues' if respond_to?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -122,6 +122,18 @@ template 'create_label.conf' do
   notifies :start, 'service[deluged]', :immediately
 end
 
+# manage extractor.conf file
+template 'create_extractor.conf' do
+  only_if { node['deluge']['config']['extractor.conf'] == true }
+  notifies :stop, 'service[deluged]', :before
+  action :create_if_missing
+  owner 'deluge'
+  group 'deluge'
+  path '/var/lib/deluge/.config/deluge/extractor.conf'
+  source 'extractor.conf.erb'
+  notifies :start, 'service[deluged]', :immediately
+end
+
 # install unrar
 package 'unrar' do
   action :install

--- a/templates/default/extractor.conf.erb
+++ b/templates/default/extractor.conf.erb
@@ -1,0 +1,7 @@
+{
+  "file": 1,
+  "format": 1
+}{
+  "use_name_folder": true,
+  "extract_path": "/.deluge/complete"
+}

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -144,6 +144,16 @@ describe command('sudo -u deluge deluge-console "plugin -s" | grep Label') do
   its('stdout') { should match 'Label' }
 end
 
+# extractor.conf file exists
+describe file('/var/lib/deluge/.config/deluge/extractor.conf') do
+  it { should be_file }
+end
+
+# Plugin Extractor is enabled
+describe command('sudo -u deluge deluge-console "plugin -s" | grep Extractor') do
+  its('stdout') { should match 'Extractor' }
+end
+
 # unrar is installed
 describe package('unrar') do
   it { should be_installed }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- update attributes to include new plugin options
- update default recipe to create new template file for extractor plugin
- update kitchen and inspec tests to include new plugin

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- resolves #30

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some torrents that are downloaded are in the multi-file .rar format and need to be extracted in order to be processed by other services (ex. Sonarr feeding completed files into Plex) This plugin should automate this procedure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Kitchen tests have been updated to include checking for this new plugin.

## Screenshots (if appropriate):
- n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
